### PR TITLE
DX-102852: Return empty results from SQLGetPrimaryKeys and SQLGetForeignKeys

### DIFF
--- a/src/test/src/catalogfunctions-test.cc
+++ b/src/test/src/catalogfunctions-test.cc
@@ -201,7 +201,7 @@ TEST_F(CatalogFunctionsTest, GetInfoTest){
   EXPECT_STREQ("table", buf);
 }
 
-TEST_F(CatalogFunctionsTest, DISABLED_PrimaryKeysTest){
+TEST_F(CatalogFunctionsTest, PrimaryKeysTest){
   rc_ = SQLPrimaryKeys(hstmt_,
                        NULL, 0,
                        (SQLCHAR *) "postgres.tpch", SQL_NTS,
@@ -212,14 +212,14 @@ TEST_F(CatalogFunctionsTest, DISABLED_PrimaryKeysTest){
                                 "TABLE_SCHEM: WVARCHAR(1024) digits: 0, nullable\n"
                                 "TABLE_NAME: WVARCHAR(1024) digits: 0, not nullable\n"
                                 "COLUMN_NAME: WVARCHAR(1024) digits: 0, not nullable\n"
-                                "KEY_SEQ: SMALLINT(5) digits: 0, not nullable\n"
+                                "KEY_SEQ: SMALLINT(2) digits: 0, not nullable\n"
                                 "PK_NAME: WVARCHAR(1024) digits: 0, nullable\n";
   std::string exp_result = "";
   EXPECT_EQ(exp_result_meta, print_result_meta(hstmt_, &err_msg).value());
   EXPECT_EQ(exp_result, get_result(hstmt_, &err_msg).value());
 }
 
-TEST_F(CatalogFunctionsTest, DISABLED_ForeignKeysTest){
+TEST_F(CatalogFunctionsTest, ForeignKeysTest){
   rc_ = SQLForeignKeys(hstmt_,
                        NULL, 0,
                        (SQLCHAR *) "postgres.tpch", SQL_NTS,
@@ -229,7 +229,20 @@ TEST_F(CatalogFunctionsTest, DISABLED_ForeignKeysTest){
                        (SQLCHAR *) "lineitem", SQL_NTS);
   CHECK_STMT_RESULT(rc_, "SQLForeignKeys failed", hstmt_);
   std::string err_msg;
-  std::string exp_result_meta = "PKTABLE_CAT: WVARCHAR(1024) digits: 0, nullable\nPKTABLE_SCHEM: WVARCHAR(1024) digits: 0, nullable\nPKTABLE_NAME: WVARCHAR(1024) digits: 0, not nullable\nPKCOLUMN_NAME: WVARCHAR(1024) digits: 0, not nullable\nFKTABLE_CAT: WVARCHAR(1024) digits: 0, nullable\nFKTABLE_SCHEM: WVARCHAR(1024) digits: 0, nullable\nFKTABLE_NAME: WVARCHAR(1024) digits: 0, not nullable\nFKCOLUMN_NAME: WVARCHAR(1024) digits: 0, not nullable\nKEY_SEQ: SMALLINT(5) digits: 0, not nullable\nUPDATE_RULE: SMALLINT(5) digits: 0, nullable\nDELETE_RULE: SMALLINT(5) digits: 0, nullable\nFK_NAME: WVARCHAR(1024) digits: 0, nullable\nPK_NAME: WVARCHAR(1024) digits: 0, nullable\nDEFERRABILITY: SMALLINT(5) digits: 0, nullable\n";
+  std::string exp_result_meta = "PKTABLE_CAT: WVARCHAR(1024) digits: 0, nullable\n"
+                              "PKTABLE_SCHEM: WVARCHAR(1024) digits: 0, nullable\n"
+                              "PKTABLE_NAME: WVARCHAR(1024) digits: 0, not nullable\n"
+                              "PKCOLUMN_NAME: WVARCHAR(1024) digits: 0, not nullable\n"
+                              "FKTABLE_CAT: WVARCHAR(1024) digits: 0, nullable\n"
+                              "FKTABLE_SCHEM: WVARCHAR(1024) digits: 0, nullable\n"
+                              "FKTABLE_NAME: WVARCHAR(1024) digits: 0, not nullable\n"
+                              "FKCOLUMN_NAME: WVARCHAR(1024) digits: 0, not nullable\n"
+                              "KEY_SEQ: SMALLINT(2) digits: 0, not nullable\n"
+                              "UPDATE_RULE: SMALLINT(2) digits: 0, nullable\n"
+                              "DELETE_RULE: SMALLINT(2) digits: 0, nullable\n"
+                              "FK_NAME: WVARCHAR(1024) digits: 0, nullable\n"
+                              "PK_NAME: WVARCHAR(1024) digits: 0, nullable\n"
+                              "DEFERRABILITY: SMALLINT(2) digits: 0, nullable\n";
   std::string exp_result = "";
   EXPECT_EQ(exp_result_meta, print_result_meta(hstmt_, &err_msg).value());
   EXPECT_EQ(exp_result, get_result(hstmt_, &err_msg).value());

--- a/src/warpdrive/info.cc
+++ b/src/warpdrive/info.cc
@@ -690,6 +690,48 @@ WD_Columns(HSTMT hstmt,
 	return SQL_SUCCESS;
 }
 
+RETCODE		SQL_API
+WD_ForeignKeys(HSTMT hstmt,
+			   const SQLCHAR *szPkCatalogName,
+			   SQLSMALLINT cbPkCatalogName,
+			   const SQLCHAR *szPkSchemaName,
+			   SQLSMALLINT cbPkSchemaName,
+			   const SQLCHAR *szPkTableName,
+			   SQLSMALLINT cbPkTableName,
+			   const SQLCHAR *szFkCatalogName,
+			   SQLSMALLINT cbFkCatalogName,
+			   const SQLCHAR *szFkSchemaName,
+			   SQLSMALLINT cbFkSchemaName,
+			   const SQLCHAR *szFkTableName,
+			   SQLSMALLINT cbFkTableName)
+{
+	CSTR func = "WD_ForeignKeys";
+	ODBCStatement* statement = reinterpret_cast<ODBCStatement*>(hstmt);
+
+	MYLOG(0, "Entering\n");
+	statement->GetForeignKeys(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+
+	return SQL_SUCCESS;
+}
+
+RETCODE		SQL_API
+WD_PrimaryKeys(HSTMT hstmt,
+			   const SQLCHAR *szCatalogName,
+			   SQLSMALLINT cbCatalogName,
+			   const SQLCHAR *szSchemaName,
+			   SQLSMALLINT cbSchemaName,
+			   const SQLCHAR *szTableName,
+			   SQLSMALLINT cbTableName,
+			   OID reloid)
+{
+	CSTR func = "WD_PrimaryKeys";
+	ODBCStatement* statement = reinterpret_cast<ODBCStatement*>(hstmt);
+
+	MYLOG(0, "Entering\n");
+	statement->GetPrimaryKeys(nullptr, nullptr, nullptr);
+
+	return SQL_SUCCESS;
+}
 
 RETCODE		SQL_API
 WD_SpecialColumns(HSTMT hstmt,

--- a/src/warpdrive/odbcapi.cc
+++ b/src/warpdrive/odbcapi.cc
@@ -819,95 +819,13 @@ SQLForeignKeys(HSTMT hstmt,
 {
   SQLRETURN rc = SQL_SUCCESS;
 	CSTR func = "SQLForeignKeys";
-        return ODBCStatement::ExecuteWithDiagnostics(hstmt, rc, [&]() -> SQLRETURN {
-          throw DriverException("Unsupported function", "HYC00");
-          RETCODE ret;
-          StatementClass *stmt = (StatementClass *)hstmt;
-          SQLCHAR *pkctName = szPkCatalogName, *pkscName = szPkSchemaName,
-                  *pktbName = szPkTableName, *fkctName = szFkCatalogName,
-                  *fkscName = szFkSchemaName, *fktbName = szFkTableName;
+  return ODBCStatement::ExecuteWithDiagnostics(hstmt, rc, [&]() -> SQLRETURN {
+    MYLOG(0, "Entering\n");
+    return WD_ForeignKeys(hstmt, szPkCatalogName, cbPkCatalogName, szPkSchemaName, cbPkSchemaName,
+                         szPkTableName, cbPkTableName, szFkCatalogName, cbFkCatalogName,
+                         szFkSchemaName, cbFkSchemaName, szFkTableName, cbFkTableName);
 
-          MYLOG(0, "Entering\n");
-          if (SC_connection_lost_check(stmt, __FUNCTION__))
-            return SQL_ERROR;
-
-          ENTER_STMT_CS(stmt);
-          SC_clear_error(stmt);
-          StartRollbackState(stmt);
-          if (SC_opencheck(stmt, func))
-            ret = SQL_ERROR;
-          /*	else
-                          ret = WD_ForeignKeys(hstmt, pkctName, cbPkCatalogName,
-                                  pkscName, cbPkSchemaName, pktbName, cbPkTableName,
-                                  fkctName, cbFkCatalogName, fkscName, cbFkSchemaName,
-                                  fktbName, cbFkTableName);*/
-          if (SQL_SUCCESS == ret && theResultIsEmpty(stmt)) {
-            BOOL ifallupper = TRUE, reexec = FALSE;
-            SQLCHAR *newPkct = NULL, *newPksc = NULL, *newPktb = NULL,
-                    *newFkct = NULL, *newFksc = NULL, *newFktb = NULL;
-            ConnectionClass *conn = SC_get_conn(stmt);
-
-            if (SC_is_lower_case(stmt, conn)) /* case-insensitive identifier */
-              ifallupper = FALSE;
-            if (newPkct = make_lstring_ifneeded(conn, szPkCatalogName,
-                                                cbPkCatalogName, ifallupper),
-                NULL != newPkct) {
-              pkctName = newPkct;
-              reexec = TRUE;
-            }
-            if (newPksc = make_lstring_ifneeded(conn, szPkSchemaName, cbPkSchemaName,
-                                                ifallupper),
-                NULL != newPksc) {
-              pkscName = newPksc;
-              reexec = TRUE;
-            }
-            if (newPktb = make_lstring_ifneeded(conn, szPkTableName, cbPkTableName,
-                                                ifallupper),
-                NULL != newPktb) {
-              pktbName = newPktb;
-              reexec = TRUE;
-            }
-            if (newFkct = make_lstring_ifneeded(conn, szFkCatalogName,
-                                                cbFkCatalogName, ifallupper),
-                NULL != newFkct) {
-              fkctName = newFkct;
-              reexec = TRUE;
-            }
-            if (newFksc = make_lstring_ifneeded(conn, szFkSchemaName, cbFkSchemaName,
-                                                ifallupper),
-                NULL != newFksc) {
-              fkscName = newFksc;
-              reexec = TRUE;
-            }
-            if (newFktb = make_lstring_ifneeded(conn, szFkTableName, cbFkTableName,
-                                                ifallupper),
-                NULL != newFktb) {
-              fktbName = newFktb;
-              reexec = TRUE;
-            }
-            if (reexec) {
-              /*	ret = WD_ForeignKeys(hstmt, pkctName, cbPkCatalogName,
-                      pkscName, cbPkSchemaName, pktbName, cbPkTableName,
-                      fkctName, cbFkCatalogName, fkscName, cbFkSchemaName,
-                      fktbName, cbFkTableName);*/
-              if (newPkct)
-                free(newPkct);
-              if (newPksc)
-                free(newPksc);
-              if (newPktb)
-                free(newPktb);
-              if (newFkct)
-                free(newFkct);
-              if (newFksc)
-                free(newFksc);
-              if (newFktb)
-                free(newFktb);
-            }
-          }
-          ret = DiscardStatementSvp(stmt, ret, FALSE);
-          LEAVE_STMT_CS(stmt);
-          return SQL_ERROR;
-              });
+        });
 }
 #endif /* UNICODE_SUPPORTXX */
 
@@ -966,66 +884,11 @@ SQLPrimaryKeys(HSTMT hstmt,
 {
   SQLRETURN rc = SQL_SUCCESS;
 	CSTR func = "SQLPrimaryKeys";
-        return ODBCStatement::ExecuteWithDiagnostics(hstmt, rc, [&]() -> SQLRETURN {
-          RETCODE ret;
-          throw DriverException("Unsupported function.", "HYC00");
-          StatementClass *stmt = (StatementClass *)hstmt;
-          SQLCHAR *ctName = szCatalogName, *scName = szSchemaName,
-                  *tbName = szTableName;
-
-          MYLOG(0, "Entering\n");
-          if (SC_connection_lost_check(stmt, __FUNCTION__))
-            return SQL_ERROR;
-
-          ENTER_STMT_CS(stmt);
-          SC_clear_error(stmt);
-          StartRollbackState(stmt);
-          if (SC_opencheck(stmt, func))
-            ret = SQL_ERROR;
-          /*else
-                  ret = WD_PrimaryKeys(hstmt, ctName, cbCatalogName,
-                          scName, cbSchemaName, tbName, cbTableName, 0);*/
-          ;
-          if (SQL_SUCCESS == ret && theResultIsEmpty(stmt)) {
-            BOOL ifallupper = TRUE, reexec = FALSE;
-            SQLCHAR *newCt = NULL, *newSc = NULL, *newTb = NULL;
-            ConnectionClass *conn = SC_get_conn(stmt);
-
-            if (SC_is_lower_case(stmt, conn)) /* case-insensitive identifier */
-              ifallupper = FALSE;
-            if (newCt = make_lstring_ifneeded(conn, szCatalogName, cbCatalogName,
-                                              ifallupper),
-                NULL != newCt) {
-              ctName = newCt;
-              reexec = TRUE;
-            }
-            if (newSc = make_lstring_ifneeded(conn, szSchemaName, cbSchemaName,
-                                              ifallupper),
-                NULL != newSc) {
-              scName = newSc;
-              reexec = TRUE;
-            }
-            if (newTb =
-                    make_lstring_ifneeded(conn, szTableName, cbTableName, ifallupper),
-                NULL != newTb) {
-              tbName = newTb;
-              reexec = TRUE;
-            }
-            if (reexec) {
-              /*	ret = WD_PrimaryKeys(hstmt, ctName, cbCatalogName,
-                      scName, cbSchemaName, tbName, cbTableName, 0);*/
-              if (newCt)
-                free(newCt);
-              if (newSc)
-                free(newSc);
-              if (newTb)
-                free(newTb);
-            }
-          }
-          ret = DiscardStatementSvp(stmt, ret, FALSE);
-          LEAVE_STMT_CS(stmt);
-          return SQL_ERROR;
-              });
+	MYLOG(0, "Entering\n");
+  return ODBCStatement::ExecuteWithDiagnostics(hstmt, rc, [&]() -> SQLRETURN {
+    return WD_PrimaryKeys(hstmt, szCatalogName, cbCatalogName,
+                          szSchemaName, cbSchemaName, szTableName, cbTableName, 0);
+  });
 }
 
 WD_EXPORT_SYMBOL

--- a/src/warpdrive/odbcapiw.cc
+++ b/src/warpdrive/odbcapiw.cc
@@ -504,31 +504,24 @@ SQLForeignKeysW(HSTMT			hstmt,
 {
   SQLRETURN rc = SQL_SUCCESS;
 	CSTR func = "SQLForeignKeysW";
-	RETCODE	ret;
-	c_ptr	ctName, scName, tbName, fkctName, fkscName, fktbName;
-	SQLLEN	nmlen1, nmlen2, nmlen3, nmlen4, nmlen5, nmlen6;
-	BOOL	lower_id = FALSE;
-
 	MYLOG(0, "Entering\n");
-        return ODBCStatement::ExecuteWithDiagnostics(hstmt, rc, [&]() -> SQLRETURN {
-          ctName.reset(wcs_to_utf8(szPkCatalogName, cbPkCatalogName, &nmlen1, lower_id));
-          scName.reset(wcs_to_utf8(szPkSchemaName, cbPkSchemaName, &nmlen2, lower_id));
-          tbName.reset(wcs_to_utf8(szPkTableName, cbPkTableName, &nmlen3, lower_id));
-          fkctName.reset(
-              wcs_to_utf8(szFkCatalogName, cbFkCatalogName, &nmlen4, lower_id));
-          fkscName.reset(wcs_to_utf8(szFkSchemaName, cbFkSchemaName, &nmlen5, lower_id));
-          fktbName.reset(wcs_to_utf8(szFkTableName, cbFkTableName, &nmlen6, lower_id));
-          throw driver::odbcabstraction::DriverException("Unsupported function", "HYC00");
-          /*		ret = WD_ForeignKeys(hstmt,
-                                                                          (SQLCHAR *)
-             ctName, (SQLSMALLINT) nmlen1, (SQLCHAR *) scName, (SQLSMALLINT) nmlen2,
-                                                                          (SQLCHAR *)
-             tbName, (SQLSMALLINT) nmlen3, (SQLCHAR *) fkctName, (SQLSMALLINT) nmlen4,
-                                                                          (SQLCHAR *)
-             fkscName, (SQLSMALLINT) nmlen5, (SQLCHAR *) fktbName, (SQLSMALLINT)
-             nmlen6);*/
-          return ret;
-              });
+  return ODBCStatement::ExecuteWithDiagnostics(hstmt, rc, [&]() -> SQLRETURN {
+      c_ptr	ctName, scName, tbName, fkctName, fkscName, fktbName;
+      SQLLEN	nmlen1, nmlen2, nmlen3, nmlen4, nmlen5, nmlen6;
+      BOOL	lower_id = FALSE;
+
+      ctName.reset(wcs_to_utf8(szPkCatalogName, cbPkCatalogName, &nmlen1, lower_id));
+      scName.reset(wcs_to_utf8(szPkSchemaName, cbPkSchemaName, &nmlen2, lower_id));
+      tbName.reset(wcs_to_utf8(szPkTableName, cbPkTableName, &nmlen3, lower_id));
+      fkctName.reset(
+          wcs_to_utf8(szFkCatalogName, cbFkCatalogName, &nmlen4, lower_id));
+      fkscName.reset(wcs_to_utf8(szFkSchemaName, cbFkSchemaName, &nmlen5, lower_id));
+      fktbName.reset(wcs_to_utf8(szFkTableName, cbFkTableName, &nmlen6, lower_id));
+
+        return WD_ForeignKeys(hstmt, (SQLCHAR *) ctName.get(), nmlen1, (SQLCHAR *) scName.get(), (SQLSMALLINT) nmlen2,
+                              (SQLCHAR *) tbName.get(), (SQLSMALLINT) nmlen3, (SQLCHAR *) fkctName.get(), (SQLSMALLINT) nmlen4,
+                              (SQLCHAR *) fkscName.get(), (SQLSMALLINT) nmlen5, (SQLCHAR *) fktbName.get(), (SQLSMALLINT) nmlen6);
+  });
 }
 
 WD_EXPORT_SYMBOL
@@ -593,7 +586,8 @@ SQLPrimaryKeysW(HSTMT			hstmt,
 {
   SQLRETURN rc = SQL_SUCCESS;
 	CSTR func = "SQLPrimaryKeysW";
-        return ODBCStatement::ExecuteWithDiagnostics(hstmt, rc, [&]() -> SQLRETURN {
+	MYLOG(0, "Entering\n");
+  return ODBCStatement::ExecuteWithDiagnostics(hstmt, rc, [&]() -> SQLRETURN {
           RETCODE ret;
           c_ptr ctName, scName, tbName;
           SQLLEN nmlen1, nmlen2, nmlen3;
@@ -603,16 +597,9 @@ SQLPrimaryKeysW(HSTMT			hstmt,
           ctName.reset(wcs_to_utf8(szCatalogName, cbCatalogName, &nmlen1, lower_id));
           scName.reset(wcs_to_utf8(szSchemaName, cbSchemaName, &nmlen2, lower_id));
           tbName.reset(wcs_to_utf8(szTableName, cbTableName, &nmlen3, lower_id));
-          throw driver::odbcabstraction::DriverException("Unsupported function", "HYC00");
-          /*else
-                  ret = WD_PrimaryKeys(hstmt,
-                                                                  (SQLCHAR *) ctName,
-             (SQLSMALLINT) nmlen1, (SQLCHAR *) scName, (SQLSMALLINT) nmlen2,
-                                                                  (SQLCHAR *) tbName,
-             (SQLSMALLINT) nmlen3, 0);*/
-          ;
-          return ret;
-              });
+    return WD_PrimaryKeys(hstmt, (SQLCHAR *) ctName.get(), cbCatalogName,
+                          (SQLCHAR *) scName.get(), cbSchemaName, (SQLCHAR *) tbName.get(), cbTableName, 0);
+  });
 }
 
 WD_EXPORT_SYMBOL


### PR DESCRIPTION
Change from throwing an error to returning empty result set.